### PR TITLE
Implement more sane object representations

### DIFF
--- a/disco/api/ratelimit.py
+++ b/disco/api/ratelimit.py
@@ -40,7 +40,7 @@ class RouteState(LoggingClass):
         self.update(response)
 
     def __repr__(self):
-        return '<RouteState {}>'.format(' '.join(self.route))
+        return '<RouteState route={}>'.format(' '.join(self.route))
 
     @property
     def chilled(self):

--- a/disco/types/application.py
+++ b/disco/types/application.py
@@ -141,7 +141,7 @@ class Interaction(SlottedModel):
     guild_locale = Field(str)
 
     def __str__(self):
-        return '<Interaction {} ({})>'.format(self.id, self.channel_id)
+        return '<Interaction id={} channel_id={}>'.format(self.id, self.channel_id)
 
     def __int__(self):
         return self.id
@@ -221,7 +221,7 @@ class InteractionResponse(Interaction):
     data = Field(InteractionCallbackData)
 
     def __str__(self):
-        return '<InteractionResponse {} ({})>'.format(self.id, self.channel_id)
+        return '<InteractionResponse id={} channel_id={}>'.format(self.id, self.channel_id)
 
     def __int__(self):
         return self.id

--- a/disco/types/application.py
+++ b/disco/types/application.py
@@ -140,7 +140,7 @@ class Interaction(SlottedModel):
     locale = Field(str)
     guild_locale = Field(str)
 
-    def __str__(self):
+    def __repr__(self):
         return '<Interaction id={} channel_id={}>'.format(self.id, self.channel_id)
 
     def __int__(self):
@@ -220,7 +220,7 @@ class InteractionResponse(Interaction):
     type = Field(enum(InteractionCallbackType))
     data = Field(InteractionCallbackData)
 
-    def __str__(self):
+    def __repr__(self):
         return '<InteractionResponse id={} channel_id={}>'.format(self.id, self.channel_id)
 
     def __int__(self):

--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -212,7 +212,7 @@ class Channel(SlottedModel, Permissible):
         return self.id
 
     def __repr__(self):
-        return '<Channel {} ({})>'.format(self.id, self)
+        return '<Channel id={} name={}>'.format(self.id, self.name)
 
     def get_permissions(self, user):
         """

--- a/disco/types/message.py
+++ b/disco/types/message.py
@@ -520,7 +520,7 @@ class _Message(SlottedModel):
     components = ListField(MessageComponent)
     sticker_items = ListField(StickerItemStructure)
 
-    def __str__(self):
+    def __repr__(self):
         return '<Message id={} channel_id={}>'.format(self.id, self.channel_id)
 
     def __int__(self):

--- a/disco/types/message.py
+++ b/disco/types/message.py
@@ -521,7 +521,7 @@ class _Message(SlottedModel):
     sticker_items = ListField(StickerItemStructure)
 
     def __str__(self):
-        return '<Message {} ({})>'.format(self.id, self.channel_id)
+        return '<Message id={} channel_id={}>'.format(self.id, self.channel_id)
 
     def __int__(self):
         return self.id

--- a/disco/types/user.py
+++ b/disco/types/user.py
@@ -110,7 +110,7 @@ class User(SlottedModel, with_equality('id'), with_hash('id')):
         return self.id
 
     def __repr__(self):
-        return '<User {} ({})>'.format(self.id, self)
+        return '<User id={} username={} discriminator={}>'.format(self.id, self.username, str(self.discriminator).zfill(4))
 
 
 class ActivityTypes:

--- a/disco/types/user.py
+++ b/disco/types/user.py
@@ -110,7 +110,7 @@ class User(SlottedModel, with_equality('id'), with_hash('id')):
         return self.id
 
     def __repr__(self):
-        return '<User id={} username={} discriminator={}>'.format(self.id, self.username, str(self.discriminator).zfill(4))
+        return '<User id={} user={}>'.format(self.id, self)
 
 
 class ActivityTypes:

--- a/disco/types/voice.py
+++ b/disco/types/voice.py
@@ -44,4 +44,4 @@ class VoiceRegion(SlottedModel):
         return self.id
 
     def __repr__(self):
-        return '<VoiceRegion {}>'.format(self.name)
+        return '<VoiceRegion name={}>'.format(self.name)

--- a/disco/voice/client.py
+++ b/disco/voice/client.py
@@ -121,7 +121,7 @@ class VoiceClient(LoggingClass):
         self.audio_ssrcs = {}
 
     def __repr__(self):
-        return '<VoiceClient server_id={}>'.format(self.server_id)
+        return '<VoiceClient guild_id={}>'.format(self.server_id)
 
     @cached_property
     def guild(self):

--- a/disco/voice/client.py
+++ b/disco/voice/client.py
@@ -121,7 +121,7 @@ class VoiceClient(LoggingClass):
         self.audio_ssrcs = {}
 
     def __repr__(self):
-        return '<VoiceClient {}>'.format(self.server_id)
+        return '<VoiceClient server_id={}>'.format(self.server_id)
 
     @cached_property
     def guild(self):


### PR DESCRIPTION
Currently, when printing string representations of some objects, it's not immediately obvious as to what IDs the strings contains. This PR seeks to clean that up by adding clear labels to the information provided. This PR also moves a few `__str__` definitions to `__repr__` as they would be better suited there.

![image](https://user-images.githubusercontent.com/14126443/180572861-c9acf4ea-cf9a-4289-81d8-8d5831ce24f3.png)